### PR TITLE
fix: adjust bottom position of label tab on small light bins

### DIFF
--- a/generators/lightbin/lightbin_generator.py
+++ b/generators/lightbin/lightbin_generator.py
@@ -144,7 +144,7 @@ class Generator:
         return result
     
     def label_tab(self, basePlane):
-        """Construct the pickip/label tab"""
+        """Construct the pickup/label tab"""
 
         result = basePlane
 
@@ -155,7 +155,6 @@ class Generator:
             basePlane.sketch()
             .segment((startX,self.brickSizeZ-labelRidgeHeight),(startX,self.brickSizeZ))
             .segment((startX+self.settings.labelRidgeWidth,self.brickSizeZ))
-            .segment((startX,self.brickSizeZ-self.settings.labelRidgeWidth))
             .close()
             .reset()
             .assemble()

--- a/help_files/compartment_help.html
+++ b/help_files/compartment_help.html
@@ -1,3 +1,3 @@
-<p>Independent of the size of the bin you can specify into how many compartments the bin should be split. So you can have a 2x2 bin with 9, 8 or 36 compartments:</p>
+<p>Independent of the size of the bin you can specify into how many compartments the bin should be split. So you can have a 2x2 bin with 9, 8 or 36 compartments.</p>
 
 <p>Note that there is a maximum to the number of compartments, which is determined by the size of your bin. You can create up to 3 compartments per unit-size in Width and Length. So a 2x2 bin can have at most 6x6 = 36 compartments, and a 1x2 bin can have at most 3x6 = 18 compartments</p>

--- a/help_files/size_help.html
+++ b/help_files/size_help.html
@@ -1,3 +1,3 @@
 <p>Bin size is defined in grid-units. For Width and Length, the grid size is 42mm, for height the grid-size is 7mm</p>
 
-<p>Note that there are limits to the size of the bins you can generate. For Width and Height the maximum is 6 units (252mm), for Height the maximum is 12 (84mm). These limits exist mainly to protect the server (larger bins are slower to generate), and these sizes are the actually larger than fit on common 3D printer beds</p>
+<p>Note that there are limits to the size of the bins you can generate. For Width and Length the maximum is 6 units (252mm), for Height the maximum is 12 (84mm). These limits exist mainly to protect the server (larger bins are slower to generate), and these sizes are actually larger than fit on common 3D printer beds</p>


### PR DESCRIPTION
When creating light bins, the generator used `self.brickSizeZ-self.settings.labelRidgeWidth` as the bottom position. However, with a height of 1 or 2 this caused the tab to extrude from the bottom of the bin. Instead of `labelRidgeWidth` this should have been `labelRidgeHeight`, i.e. returning to start position (now covered by `close()`)

Also fixed some typos I stumbled upon..

Fixes #32.

Before:
<img width="612" height="710" alt="old-1-1-2" src="https://github.com/user-attachments/assets/4879a29d-ddc5-410b-ba54-ffd06b8d2c34" />


After:
<img width="646" height="750" alt="new-1-1-2" src="https://github.com/user-attachments/assets/03af0835-d0cd-41dc-9084-15457cf4aedc" />

